### PR TITLE
Add custom setup script and improve installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Claude Desktop Commander MCP
 
-[![npm downloads](https://img.shields.io/npm/dw/@wonderwhy-er/desktop-commander)](https://www.npmjs.com/package/@wonderwhy-er/desktop-commander)
-[![smithery badge](https://smithery.ai/badge/@wonderwhy-er/desktop-commander)](https://smithery.ai/server/@wonderwhy-er/desktop-commander)
-
+[![npm downloads](https://img.shields.io/npm/dw/@jasondsmith72/desktop-commander)](https://www.npmjs.com/package/@jasondsmith72/desktop-commander)
+[![GitHub Repo](https://img.shields.io/badge/GitHub-jasondsmith72%2FClaudeComputerCommander-blue)](https://github.com/jasondsmith72/ClaudeComputerCommander)
 
 Short version. Two key things. Terminal commands and diff based file editing.
 
-This is server that allows Claude desktop app to execute long-running terminal commands on your computer and manage processes through Model Context Protocol (MCP) + Built on top of [MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) to provide additional search and replace file editing capabilities .
+This is a server that allows Claude desktop app to execute long-running terminal commands on your computer and manage processes through Model Context Protocol (MCP) + Built on top of [MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) to provide additional search and replace file editing capabilities.
+
+This is a fork of [wonderwhy-er/ClaudeComputerCommander](https://github.com/wonderwhy-er/ClaudeComputerCommander) with custom setup options.
 
 ## Features
 
@@ -29,23 +30,42 @@ This is server that allows Claude desktop app to execute long-running terminal c
 ## Installation
 First, ensure you've downloaded and installed the [Claude Desktop app](https://claude.ai/download) and you have [npm installed](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-### Option 1: Installing via Smithery
+### Option 1: Custom Setup (Recommended)
+This method is best if you don't have permissions to directly modify the Claude config file or prefer a guided approach:
 
-To install Desktop Commander for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wonderwhy-er/desktop-commander):
+1. Clone the repository:
+```bash
+git clone https://github.com/jasondsmith72/ClaudeComputerCommander.git
+cd ClaudeComputerCommander
+```
+
+2. Checkout the custom-setup branch:
+```bash
+git checkout custom-setup
+```
+
+3. Run the custom setup:
+```bash
+npm run setup:custom
+```
+
+4. Follow the on-screen instructions to update your Claude config file manually.
+
+5. Restart Claude if it's running.
+
+### Option 2: Regular Setup
+If you have permissions to modify the Claude config file:
 
 ```bash
-npx -y @smithery/cli install @wonderwhy-er/desktop-commander --client claude
+git clone https://github.com/jasondsmith72/ClaudeComputerCommander.git
+cd ClaudeComputerCommander
+npm run setup
 ```
 
-### Option 2: Install trough npx
-Just run this in terminal
-```
-npx @wonderwhy-er/desktop-commander setup
-```
-Restart Claude if running
+Restart Claude if running.
 
-### Option 3: Add to claude_desktop_config by hand
-Add this entry to your claude_desktop_config.json (on Mac, found at ~/Library/Application\ Support/Claude/claude_desktop_config.json):
+### Option 3: Add to claude_desktop_config manually
+Add this entry to your claude_desktop_config.json (on Windows, found at %APPDATA%\Claude\claude_desktop_config.json):
 ```json
 {
   "mcpServers": {
@@ -53,28 +73,13 @@ Add this entry to your claude_desktop_config.json (on Mac, found at ~/Library/Ap
       "command": "npx",
       "args": [
         "-y",
-        "@wonderwhy-er/desktop-commander"
+        "@jasondsmith72/desktop-commander"
       ]
     }
   }
 }
 ```
-Restart Claude if running
-
-### Option 4: Checkout locally
-1. Clone and build:
-```bash
-git clone https://github.com/wonderwhy-er/ClaudeComputerCommander.git
-cd ClaudeComputerCommander
-npm run setup
-```
-Restart Claude if running
-
-The setup command will:
-- Install dependencies
-- Build the server
-- Configure Claude's desktop app
-- Add MCP servers to Claude's config if needed
+Restart Claude if running.
 
 ## Usage
 
@@ -138,7 +143,15 @@ This project extends the MCP Filesystem Server to enable:
 - File operations
 - Code editing with search/replace blocks
 
-Created as part of exploring Claude MCPs: https://youtube.com/live/TlbjFDbl5Us
+## Troubleshooting
+
+If you encounter issues setting up or using the MCP server:
+
+1. Check that Claude Desktop is properly installed and has been run at least once
+2. Verify that the claude_desktop_config.json file exists and is properly formatted
+3. Make sure you have the required permissions to modify the config file
+4. Restart Claude Desktop after making changes to the config
+5. Check the setup log file (setup-custom.log) for any error messages
 
 ## Contributing
 
@@ -146,7 +159,7 @@ If you find this project useful, please consider giving it a ⭐ star on GitHub!
 
 We welcome contributions from the community! Whether you've found a bug, have a feature request, or want to contribute code, here's how you can help:
 
-- **Found a bug?** Open an issue at [github.com/wonderwhy-er/ClaudeComputerCommander/issues](https://github.com/wonderwhy-er/ClaudeComputerCommander/issues)
+- **Found a bug?** Open an issue at [github.com/jasondsmith72/ClaudeComputerCommander/issues](https://github.com/jasondsmith72/ClaudeComputerCommander/issues)
 - **Have a feature idea?** Submit a feature request in the issues section
 - **Want to contribute code?** Fork the repository, create a branch, and submit a pull request
 - **Questions or discussions?** Start a discussion in the GitHub Discussions tab

--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
-  "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.1.19",
-  "description": "MCP server for terminal operations and file editing",
+  "name": "@jasondsmith72/desktop-commander",
+  "version": "0.1.20",
+  "description": "MCP server for terminal operations and file editing with custom setup",
   "license": "MIT",
   "author": "Eduards Ruzga",
-  "homepage": "https://github.com/wonderwhy-er/ClaudeComputerCommander",
-  "bugs": "https://github.com/wonderwhy-er/ClaudeComputerCommander/issues",
+  "contributors": [
+    "Jason Smith"
+  ],
+  "homepage": "https://github.com/jasondsmith72/ClaudeComputerCommander",
+  "bugs": "https://github.com/jasondsmith72/ClaudeComputerCommander/issues",
   "type": "module",
   "bin": {
     "desktop-commander": "dist/index.js",
-    "setup": "dist/setup-claude-server.js"
+    "setup": "dist/setup-claude-server.js",
+    "setup-custom": "dist/setup-claude-custom.js"
   },
   "files": [
     "dist"
@@ -19,10 +23,11 @@
     "bump": "node scripts/sync-version.js --bump",
     "bump:minor": "node scripts/sync-version.js --bump --minor",
     "bump:major": "node scripts/sync-version.js --bump --major",
-    "build": "tsc && shx cp setup-claude-server.js dist/ && shx chmod +x dist/*.js",
+    "build": "tsc && shx cp setup-claude-server.js dist/ && shx cp setup-claude-custom.js dist/ && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "setup": "npm install && npm run build && node setup-claude-server.js",
+    "setup:custom": "npm install && npm run build && node setup-claude-custom.js",
     "prepare": "npm run build",
     "test": "node test/test.js",
     "test:watch": "nodemon test/test.js",

--- a/setup-claude-custom.js
+++ b/setup-claude-custom.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { homedir, platform } from 'os';
+import { join } from 'path';
+import { readFileSync, writeFileSync, existsSync, appendFileSync, copyFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { execSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Determine OS and set appropriate config path and command
+const isWindows = platform() === 'win32';
+const claudeConfigPath = isWindows
+    ? join(process.env.APPDATA, 'Claude', 'claude_desktop_config.json')
+    : join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+
+// Create backup filename with timestamp
+const getBackupFilename = (originalPath) => {
+    const now = new Date();
+    const timestamp = `${now.getFullYear()}.${(now.getMonth() + 1).toString().padStart(2, '0')}.${now.getDate().toString().padStart(2, '0')}-${now.getHours().toString().padStart(2, '0')}.${now.getMinutes().toString().padStart(2, '0')}`;
+    const pathObj = originalPath.split('.');
+    const extension = pathObj.pop();
+    return `${pathObj.join('.')}-bk-${timestamp}.${extension}`;
+};
+
+// Setup logging
+const LOG_FILE = join(__dirname, 'setup-custom.log');
+
+function logToFile(message, isError = false) {
+    const timestamp = new Date().toISOString();
+    const logMessage = `${timestamp} - ${isError ? 'ERROR: ' : ''}${message}\n`;
+    try {
+        appendFileSync(LOG_FILE, logMessage);
+        // For setup script, we'll still output to console
+        console.log(isError ? `ERROR: ${message}` : message);
+    } catch (err) {
+        // Last resort error handling
+        console.error(`Failed to write to log file: ${err.message}`);
+    }
+}
+
+// Main setup function
+async function setup() {
+    logToFile('Starting custom setup for ClaudeComputerCommander...');
+
+    // Check if config file exists
+    if (!existsSync(claudeConfigPath)) {
+        logToFile(`Claude config file not found at: ${claudeConfigPath}`, true);
+        logToFile('Please make sure Claude Desktop is installed and has been run at least once.');
+        process.exit(1);
+    }
+
+    // Create backup of config file
+    const backupPath = getBackupFilename(claudeConfigPath);
+    try {
+        copyFileSync(claudeConfigPath, backupPath);
+        logToFile(`Created backup of Claude config at: ${backupPath}`);
+    } catch (err) {
+        logToFile(`Error creating backup: ${err.message}`, true);
+        logToFile('Please make sure you have permissions to write to the Claude config directory.');
+        process.exit(1);
+    }
+
+    // Read config content
+    let configContent;
+    try {
+        configContent = readFileSync(claudeConfigPath, 'utf8');
+        logToFile('Successfully read Claude configuration');
+    } catch (err) {
+        logToFile(`Error reading Claude configuration: ${err.message}`, true);
+        process.exit(1);
+    }
+
+    // Parse config as JSON
+    let config;
+    try {
+        config = JSON.parse(configContent);
+        logToFile('Successfully parsed Claude configuration');
+    } catch (err) {
+        logToFile(`Error parsing Claude configuration: ${err.message}`, true);
+        logToFile('The configuration file appears to be invalid JSON.');
+        process.exit(1);
+    }
+
+    // Ensure mcpServers section exists
+    if (!config.mcpServers) {
+        config.mcpServers = {};
+        logToFile('Added mcpServers section to configuration');
+    }
+
+    // Determine if running through npx or locally
+    const isNpx = import.meta.url.endsWith('dist/setup-claude-custom.js');
+
+    // Add or update the desktop commander server configuration
+    const serverConfig = isNpx ? {
+        "command": "npx",
+        "args": [
+            "@wonderwhy-er/desktop-commander"
+        ]
+    } : {
+        "command": "node",
+        "args": [
+            join(__dirname, 'dist', 'index.js')
+        ]
+    };
+
+    // Add desktopCommander server
+    config.mcpServers.desktopCommander = serverConfig;
+    logToFile('Added desktopCommander to mcpServers configuration');
+
+    // Create the updated config content
+    const updatedConfigContent = JSON.stringify(config, null, 2);
+
+    // Log the config changes that would be made
+    logToFile('\nHere is the configuration that needs to be applied to Claude:');
+    logToFile('-----------------------------------------------------------------');
+    logToFile(updatedConfigContent);
+    logToFile('-----------------------------------------------------------------');
+    
+    // Provide manual instructions
+    logToFile('\nMANUAL CONFIGURATION INSTRUCTIONS:');
+    logToFile('1. Open your Claude Desktop config file at:');
+    logToFile(`   ${claudeConfigPath}`);
+    logToFile('2. Replace the current content with the configuration shown above');
+    logToFile('3. Save the file');
+    logToFile('4. Restart Claude Desktop if it is currently running');
+    logToFile('\nAfter applying these changes, the desktopCommander MCP server will be available in Claude.');
+    
+    // Final message
+    logToFile('\nSetup instructions generated successfully!');
+}
+
+// Run the setup
+setup().catch(err => {
+    logToFile(`Unhandled error during setup: ${err.message}`, true);
+    process.exit(1);
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.1.19';
+export const VERSION = '0.1.20';


### PR DESCRIPTION
This PR adds a custom setup script to help users who might not have direct access to modify the Claude Desktop configuration file. It also updates the package information to reflect the fork and includes comprehensive documentation.

Changes:
- Added `setup-claude-custom.js` with a guided approach for manual configuration
- Updated package.json with new metadata, scripts, and package name
- Updated README with detailed installation instructions and troubleshooting tips
- Bumped version to 0.1.20

The custom setup script:
1. Creates a backup of the existing Claude config file
2. Reads and parses the configuration
3. Generates the updated configuration needed
4. Provides clear instructions for manual installation

This approach makes the tool more accessible to users in restricted environments or those who prefer a guided setup process.