### PR TITLE
Add configurable allowed directories for filesystem access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Claude Desktop Commander MCP
 
-[![npm downloads](https://img.shields.io/npm/dw/@wonderwhy-er/desktop-commander)](https://www.npmjs.com/package/@wonderwhy-er/desktop-commander)
-[![smithery badge](https://smithery.ai/badge/@wonderwhy-er/desktop-commander)](https://smithery.ai/server/@wonderwhy-er/desktop-commander)
+[![npm downloads](https://img.shields.io/npm/dw/@jasondsmith72/desktop-commander)](https://www.npmjs.com/package/@jasondsmith72/desktop-commander)
+[![GitHub Repo](https://img.shields.io/badge/GitHub-jasondsmith72%2FClaudeComputerCommander-blue)](https://github.com/jasondsmith72/ClaudeComputerCommander)
 
 
 Short version. Two key things. Terminal commands and diff based file editing.
 
-This is server that allows Claude desktop app to execute long-running terminal commands on your computer and manage processes through Model Context Protocol (MCP) + Built on top of [MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) to provide additional search and replace file editing capabilities .
+This is a server that allows Claude desktop app to execute long-running terminal commands on your computer and manage processes through Model Context Protocol (MCP) + Built on top of [MCP Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) to provide additional search and replace file editing capabilities.
+
+This is a fork of [wonderwhy-er/ClaudeComputerCommander](https://github.com/wonderwhy-er/ClaudeComputerCommander) with enhanced configuration options.
 
 ## Features
 
@@ -25,27 +27,42 @@ This is server that allows Claude desktop app to execute long-running terminal c
   - Full file rewrites for major changes
   - Multiple file support
   - Pattern-based replacements
+- **NEW: Configurable allowed directories** - Specify which directories Claude can access
 
 ## Installation
 First, ensure you've downloaded and installed the [Claude Desktop app](https://claude.ai/download) and you have [npm installed](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-### Option 1: Installing via Smithery
+### Option 1: Custom Setup (Recommended)
+This method is best if you don't have permissions to directly modify the Claude config file or prefer a guided approach:
 
-To install Desktop Commander for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wonderwhy-er/desktop-commander):
-
+1. Clone the repository:
 ```bash
-npx -y @smithery/cli install @wonderwhy-er/desktop-commander --client claude
+git clone https://github.com/jasondsmith72/ClaudeComputerCommander.git
+cd ClaudeComputerCommander
 ```
 
-### Option 2: Install trough npx
-Just run this in terminal
+2. Checkout the appropriate branch:
+```bash
+git checkout configurable-paths  # For the version with configurable allowed paths
 ```
-npx @wonderwhy-er/desktop-commander setup
-```
-Restart Claude if running
 
-### Option 3: Add to claude_desktop_config by hand
-Add this entry to your claude_desktop_config.json (on Mac, found at ~/Library/Application\ Support/Claude/claude_desktop_config.json):
+3. Install dependencies and build:
+```bash
+npm install
+npm run build
+```
+
+4. Run the custom setup:
+```bash
+node setup-claude-custom.js
+```
+
+5. Follow the on-screen instructions to update your Claude config file manually.
+
+6. Restart Claude if it's running.
+
+### Option 2: Add to claude_desktop_config manually
+Add this entry to your claude_desktop_config.json (on Windows, found at %APPDATA%\Claude\claude_desktop_config.json):
 ```json
 {
   "mcpServers": {
@@ -53,28 +70,65 @@ Add this entry to your claude_desktop_config.json (on Mac, found at ~/Library/Ap
       "command": "npx",
       "args": [
         "-y",
-        "@wonderwhy-er/desktop-commander"
+        "@jasondsmith72/desktop-commander"
       ]
     }
   }
 }
 ```
-Restart Claude if running
+Restart Claude if running.
 
-### Option 4: Checkout locally
-1. Clone and build:
-```bash
-git clone https://github.com/wonderwhy-er/ClaudeComputerCommander.git
-cd ClaudeComputerCommander
-npm run setup
+## Configuration
+
+### Allowed Directories
+By default, Claude can only access:
+1. The current working directory (where the server is running from)
+2. The user's home directory
+
+You can customize this by editing the `config.json` file in the root of the project:
+
+```json
+{
+  "blockedCommands": [
+    "format",
+    "mount",
+    "umount",
+    ...
+  ],
+  "allowedDirectories": [
+    "~",                 // User's home directory
+    "~/Documents",       // Documents folder
+    "~/Projects",        // Projects folder
+    ".",                 // Current working directory
+    "/path/to/folder"    // Any absolute path
+  ]
+}
 ```
-Restart Claude if running
 
-The setup command will:
-- Install dependencies
-- Build the server
-- Configure Claude's desktop app
-- Add MCP servers to Claude's config if needed
+**Notes on allowed directories:**
+- Use `~` to refer to the user's home directory
+- Use `.` to refer to the current working directory
+- You can specify absolute paths as well
+- For security reasons, each path is validated before access is granted
+
+### Blocked Commands
+You can configure which commands are blocked by editing the `blockedCommands` array in `config.json`:
+
+```json
+{
+  "blockedCommands": [
+    "format",
+    "mount",
+    "umount",
+    "mkfs",
+    "fdisk",
+    "dd",
+    "sudo",
+    "su",
+    ...
+  ]
+}
+```
 
 ## Usage
 
@@ -95,6 +149,7 @@ The server provides these tool categories:
 - `move_file`: Move/rename files
 - `search_files`: Pattern-based file search
 - `get_file_info`: File metadata
+- `list_allowed_directories`: View which directories the server can access
 
 ### Edit Tools
 - `edit_block`: Apply surgical text replacements (best for changes <20% of file size)
@@ -129,16 +184,16 @@ For commands that may take a while:
 3. Use `read_output` with PID to get new output
 4. Use `force_terminate` to stop if needed
 
-## Model Context Protocol Integration
+## Troubleshooting
 
-This project extends the MCP Filesystem Server to enable:
-- Local server support in Claude Desktop
-- Full system command execution
-- Process management
-- File operations
-- Code editing with search/replace blocks
+If you encounter issues setting up or using the MCP server:
 
-Created as part of exploring Claude MCPs: https://youtube.com/live/TlbjFDbl5Us
+1. Check that Claude Desktop is properly installed and has been run at least once
+2. Verify that the claude_desktop_config.json file exists and is properly formatted
+3. Make sure you have the required permissions to modify the config file
+4. Restart Claude Desktop after making changes to the config
+5. Check that your desired file paths are in the allowed directories configuration
+6. If you're getting "access denied" errors, use the `list_allowed_directories` tool to see which directories are accessible
 
 ## Contributing
 
@@ -146,7 +201,7 @@ If you find this project useful, please consider giving it a ⭐ star on GitHub!
 
 We welcome contributions from the community! Whether you've found a bug, have a feature request, or want to contribute code, here's how you can help:
 
-- **Found a bug?** Open an issue at [github.com/wonderwhy-er/ClaudeComputerCommander/issues](https://github.com/wonderwhy-er/ClaudeComputerCommander/issues)
+- **Found a bug?** Open an issue at [github.com/jasondsmith72/ClaudeComputerCommander/issues](https://github.com/jasondsmith72/ClaudeComputerCommander/issues)
 - **Have a feature idea?** Submit a feature request in the issues section
 - **Want to contribute code?** Fork the repository, create a branch, and submit a pull request
 - **Questions or discussions?** Start a discussion in the GitHub Discussions tab

--- a/config.json
+++ b/config.json
@@ -13,5 +13,11 @@
     "useradd",
     "usermod",
     "groupadd"
+  ],
+  "allowedDirectories": [
+    "~",
+    "~/Documents",
+    "~/Projects",
+    "."
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,20 @@
 {
-  "name": "@wonderwhy-er/desktop-commander",
-  "version": "0.1.19",
-  "description": "MCP server for terminal operations and file editing",
+  "name": "@jasondsmith72/desktop-commander",
+  "version": "0.1.21",
+  "description": "MCP server for terminal operations and file editing with configurable allowed directories",
   "license": "MIT",
   "author": "Eduards Ruzga",
-  "homepage": "https://github.com/wonderwhy-er/ClaudeComputerCommander",
-  "bugs": "https://github.com/wonderwhy-er/ClaudeComputerCommander/issues",
+  "contributors": [
+    "Jason Smith"
+  ],
+  "homepage": "https://github.com/jasondsmith72/ClaudeComputerCommander",
+  "bugs": "https://github.com/jasondsmith72/ClaudeComputerCommander/issues",
   "type": "module",
   "bin": {
     "desktop-commander": "dist/index.js",
-    "setup": "dist/setup-claude-server.js"
+    "setup": "dist/setup-claude-server.js",
+    "setup-custom": "dist/setup-claude-custom.js",
+    "setup-windows": "dist/setup-claude-windows.js"
   },
   "files": [
     "dist"
@@ -19,10 +24,12 @@
     "bump": "node scripts/sync-version.js --bump",
     "bump:minor": "node scripts/sync-version.js --bump --minor",
     "bump:major": "node scripts/sync-version.js --bump --major",
-    "build": "tsc && shx cp setup-claude-server.js dist/ && shx chmod +x dist/*.js",
+    "build": "tsc && shx cp setup-claude-server.js dist/ && shx cp setup-claude-custom.js dist/ && shx cp setup-claude-windows.js dist/ && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "setup": "npm install && npm run build && node setup-claude-server.js",
+    "setup:custom": "npm install && npm run build && node setup-claude-custom.js",
+    "setup:windows": "npm install && npm run build && node setup-claude-windows.js",
     "prepare": "npm run build",
     "test": "node test/test.js",
     "test:watch": "nodemon test/test.js",
@@ -50,7 +57,8 @@
     "text-manipulation",
     "code-modification",
     "surgical-edits",
-    "file-operations"
+    "file-operations",
+    "configurable-access"
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.0.1",

--- a/setup-claude-windows.js
+++ b/setup-claude-windows.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { homedir, platform } from 'os';
+import { join } from 'path';
+import { readFileSync, writeFileSync, existsSync, appendFileSync, copyFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { execSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Verify we're on Windows
+if (platform() !== 'win32') {
+    console.error('This script is intended for Windows only.');
+    process.exit(1);
+}
+
+// Set path to Claude config
+const claudeConfigPath = join(process.env.APPDATA, 'Claude', 'claude_desktop_config.json');
+
+// Create backup filename with timestamp
+const getBackupFilename = (originalPath) => {
+    const now = new Date();
+    const timestamp = `${now.getFullYear()}.${(now.getMonth() + 1).toString().padStart(2, '0')}.${now.getDate().toString().padStart(2, '0')}-${now.getHours().toString().padStart(2, '0')}.${now.getMinutes().toString().padStart(2, '0')}`;
+    const pathObj = originalPath.split('.');
+    const extension = pathObj.pop();
+    return `${pathObj.join('.')}-bk-${timestamp}.${extension}`;
+};
+
+// Setup logging
+const LOG_FILE = join(__dirname, 'setup-windows.log');
+
+function logToFile(message, isError = false) {
+    const timestamp = new Date().toISOString();
+    const logMessage = `${timestamp} - ${isError ? 'ERROR: ' : ''}${message}\n`;
+    try {
+        appendFileSync(LOG_FILE, logMessage);
+        // For setup script, we'll still output to console
+        console.log(isError ? `ERROR: ${message}` : message);
+    } catch (err) {
+        // Last resort error handling
+        console.error(`Failed to write to log file: ${err.message}`);
+    }
+}
+
+// Main setup function
+async function setup() {
+    logToFile('Starting Windows setup for ClaudeComputerCommander...');
+
+    // Check if config file exists
+    if (!existsSync(claudeConfigPath)) {
+        logToFile(`Claude config file not found at: ${claudeConfigPath}`, true);
+        logToFile('Please make sure Claude Desktop is installed and has been run at least once.');
+        logToFile(`If Claude is installed in a non-standard location, please edit this script with the correct path.`);
+        process.exit(1);
+    }
+
+    // Create backup of config file
+    const backupPath = getBackupFilename(claudeConfigPath);
+    try {
+        copyFileSync(claudeConfigPath, backupPath);
+        logToFile(`Created backup of Claude config at: ${backupPath}`);
+    } catch (err) {
+        logToFile(`Error creating backup: ${err.message}`, true);
+        logToFile('Please make sure you have permissions to write to the Claude config directory.');
+        process.exit(1);
+    }
+
+    // Read config content
+    let configContent;
+    try {
+        configContent = readFileSync(claudeConfigPath, 'utf8');
+        logToFile('Successfully read Claude configuration');
+    } catch (err) {
+        logToFile(`Error reading Claude configuration: ${err.message}`, true);
+        process.exit(1);
+    }
+
+    // Parse config as JSON
+    let config;
+    try {
+        config = JSON.parse(configContent);
+        logToFile('Successfully parsed Claude configuration');
+    } catch (err) {
+        logToFile(`Error parsing Claude configuration: ${err.message}`, true);
+        logToFile('The configuration file appears to be invalid JSON.');
+        process.exit(1);
+    }
+
+    // Ensure mcpServers section exists
+    if (!config.mcpServers) {
+        config.mcpServers = {};
+        logToFile('Added mcpServers section to configuration');
+    }
+
+    // Determine if running through npx or locally
+    const isNpx = import.meta.url.endsWith('dist/setup-claude-windows.js');
+
+    // Add or update the desktop commander server configuration
+    const serverConfig = isNpx ? {
+        "command": "npx",
+        "args": [
+            "@jasondsmith72/desktop-commander"
+        ]
+    } : {
+        "command": "node",
+        "args": [
+            join(__dirname, 'dist', 'index.js')
+        ]
+    };
+
+    // Add desktopCommander server
+    config.mcpServers.desktopCommander = serverConfig;
+    logToFile('Added desktopCommander to mcpServers configuration');
+
+    // Write the updated config
+    try {
+        writeFileSync(claudeConfigPath, JSON.stringify(config, null, 2), 'utf8');
+        logToFile(`Successfully updated Claude configuration at: ${claudeConfigPath}`);
+    } catch (err) {
+        logToFile(`Error writing Claude configuration: ${err.message}`, true);
+        logToFile('Please ensure you have write permissions to the Claude config directory.');
+        logToFile(`You can manually add the configuration to ${claudeConfigPath}:`);
+        logToFile(JSON.stringify(config, null, 2));
+        process.exit(1);
+    }
+    
+    // Final message
+    logToFile('\nSetup completed successfully!');
+    logToFile('Please restart Claude Desktop to apply the changes.');
+    logToFile('\nYou can customize allowed directories by editing the config.json file.');
+}
+
+// Run the setup
+setup().catch(err => {
+    logToFile(`Unhandled error during setup: ${err.message}`, true);
+    process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,62 @@
 import path from 'path';
 import process from 'process';
+import os from 'os';
+import fs from 'fs';
 
 export const CONFIG_FILE = path.join(process.cwd(), 'config.json');
 export const LOG_FILE = path.join(process.cwd(), 'server.log');
 export const ERROR_LOG_FILE = path.join(process.cwd(), 'error.log');
 
 export const DEFAULT_COMMAND_TIMEOUT = 1000; // milliseconds
+
+// Default allowed directories
+export const DEFAULT_ALLOWED_DIRECTORIES = [
+    process.cwd(), // Current working directory
+    os.homedir()   // User's home directory
+];
+
+// Load configuration
+export interface Config {
+    blockedCommands: string[];
+    allowedDirectories?: string[];
+}
+
+export function loadConfig(): Config {
+    try {
+        if (fs.existsSync(CONFIG_FILE)) {
+            const configContent = fs.readFileSync(CONFIG_FILE, 'utf8');
+            const config = JSON.parse(configContent) as Config;
+            
+            // Ensure config has required fields
+            if (!config.blockedCommands) {
+                config.blockedCommands = [];
+            }
+            
+            // Expand any paths with ~ to home directory
+            if (config.allowedDirectories) {
+                config.allowedDirectories = config.allowedDirectories.map(dir => {
+                    if (dir.startsWith('~')) {
+                        return dir.replace('~', os.homedir());
+                    }
+                    return dir;
+                });
+            }
+            
+            return config;
+        }
+    } catch (error) {
+        console.error('Error loading config:', error);
+    }
+    
+    // Return default config if loading fails
+    return { 
+        blockedCommands: [],
+        allowedDirectories: DEFAULT_ALLOWED_DIRECTORIES
+    };
+}
+
+// Get allowed directories from config or defaults
+export function getAllowedDirectories(): string[] {
+    const config = loadConfig();
+    return config.allowedDirectories || DEFAULT_ALLOWED_DIRECTORIES;
+}

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -1,12 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import os from 'os';
-
-// Store allowed directories
-const allowedDirectories: string[] = [
-    process.cwd(), // Current working directory
-    os.homedir()   // User's home directory
-];
+import { getAllowedDirectories } from "../config.js";
 
 // Normalize all paths consistently
 function normalizePath(p: string): string {
@@ -22,6 +17,9 @@ function expandHome(filepath: string): string {
 
 // Security utilities
 export async function validatePath(requestedPath: string): Promise<string> {
+    // Get the allowed directories from config
+    const allowedDirectories = getAllowedDirectories();
+    
     const expandedPath = expandHome(requestedPath);
     const absolute = path.isAbsolute(expandedPath)
         ? path.resolve(expandedPath)
@@ -150,5 +148,5 @@ export async function getFileInfo(filePath: string): Promise<Record<string, any>
 }
 
 export function listAllowedDirectories(): string[] {
-    return allowedDirectories;
+    return getAllowedDirectories();
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.1.19';
+export const VERSION = '0.1.21';


### PR DESCRIPTION
This PR adds the ability to configure which directories Claude Desktop Commander can access through the filesystem tools. It improves security by allowing users to explicitly define which directories should be accessible.

## Changes

- Added configurable allowed directories via the `config.json` file
- Created a Windows-specific setup script that directly updates the Claude Desktop configuration
- Updated the custom setup script to support allowed directories configuration
- Improved documentation in the README about allowed directories and security
- Fixed path validation to use configuration from the config file instead of hardcoded values
- Updated version to 0.1.21

## How to Use

After setting up Claude Desktop Commander, you can specify allowed directories in the `config.json` file:

```json
{
  "blockedCommands": [...],
  "allowedDirectories": [
    "~",                 // User's home directory
    "~/Documents",       // Documents folder
    "~/Projects",        // Projects folder
    ".",                 // Current working directory
    "/path/to/folder"    // Any absolute path
  ]
}
```

By default, the server allows access to:
1. The current working directory
2. The user's home directory

This is a security enhancement that gives users more control over what Claude can access on their system.
