### PR TITLE
Add uninstall script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is a fork of [wonderwhy-er/ClaudeComputerCommander](https://github.com/wond
   - Multiple file support
   - Pattern-based replacements
 - **NEW: Configurable allowed directories** - Specify which directories Claude can access
+- **NEW: Uninstall script** - Easy removal of the tool from Claude Desktop
 
 ## Installation
 First, ensure you've downloaded and installed the [Claude Desktop app](https://claude.ai/download) and you have [npm installed](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
@@ -41,25 +42,27 @@ git clone https://github.com/jasondsmith72/ClaudeComputerCommander.git
 cd ClaudeComputerCommander
 ```
 
-2. Checkout the appropriate branch:
-```bash
-git checkout configurable-paths  # For the version with configurable allowed paths
-```
-
-3. Install dependencies and build:
+2. Install dependencies and build:
 ```bash
 npm install
 npm run build
 ```
 
-4. Run the custom setup:
+3. Run the appropriate setup script based on your needs:
 ```bash
-node setup-claude-custom.js
+# For Windows with automatic configuration:
+npm run setup:windows
+
+# For guided manual setup (works on any platform):
+npm run setup:custom
+
+# For standard setup (requires write access to Claude config):
+npm run setup
 ```
 
-5. Follow the on-screen instructions to update your Claude config file manually.
+4. Follow any on-screen instructions provided by the setup script.
 
-6. Restart Claude if it's running.
+5. Restart Claude if it's running.
 
 ### Option 2: Add to claude_desktop_config manually
 Add this entry to your claude_desktop_config.json (on Windows, found at %APPDATA%\Claude\claude_desktop_config.json):
@@ -77,6 +80,43 @@ Add this entry to your claude_desktop_config.json (on Windows, found at %APPDATA
 }
 ```
 Restart Claude if running.
+
+## Uninstallation
+
+To uninstall ClaudeComputerCommander, you have two options:
+
+### Option 1: Using the uninstall script (Recommended)
+
+If you have the repository locally:
+```bash
+cd ClaudeComputerCommander
+npm run uninstall
+```
+
+If you've installed it globally:
+```bash
+npx @jasondsmith72/desktop-commander uninstall
+```
+
+This will:
+1. Create a backup of your Claude configuration file
+2. Remove all references to desktopCommander from the configuration
+3. Log the changes made for reference
+
+### Option 2: Manual uninstallation
+
+1. Open your Claude Desktop configuration file:
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+   - Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+2. Remove the `desktopCommander` entry from the `mcpServers` section.
+
+3. Restart Claude Desktop.
+
+4. If you installed the package globally, uninstall it:
+   ```bash
+   npm uninstall -g @jasondsmith72/desktop-commander
+   ```
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jasondsmith72/desktop-commander",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "MCP server for terminal operations and file editing with configurable allowed directories",
   "license": "MIT",
   "author": "Eduards Ruzga",
@@ -14,7 +14,8 @@
     "desktop-commander": "dist/index.js",
     "setup": "dist/setup-claude-server.js",
     "setup-custom": "dist/setup-claude-custom.js",
-    "setup-windows": "dist/setup-claude-windows.js"
+    "setup-windows": "dist/setup-claude-windows.js",
+    "uninstall": "dist/uninstall.js"
   },
   "files": [
     "dist"
@@ -24,12 +25,13 @@
     "bump": "node scripts/sync-version.js --bump",
     "bump:minor": "node scripts/sync-version.js --bump --minor",
     "bump:major": "node scripts/sync-version.js --bump --major",
-    "build": "tsc && shx cp setup-claude-server.js dist/ && shx cp setup-claude-custom.js dist/ && shx cp setup-claude-windows.js dist/ && shx chmod +x dist/*.js",
+    "build": "tsc && shx cp setup-claude-server.js dist/ && shx cp setup-claude-custom.js dist/ && shx cp setup-claude-windows.js dist/ && shx cp uninstall.js dist/ && shx chmod +x dist/*.js",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "setup": "npm install && npm run build && node setup-claude-server.js",
     "setup:custom": "npm install && npm run build && node setup-claude-custom.js",
     "setup:windows": "npm install && npm run build && node setup-claude-windows.js",
+    "uninstall": "node uninstall.js",
     "prepare": "npm run build",
     "test": "node test/test.js",
     "test:watch": "nodemon test/test.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.1.21';
+export const VERSION = '0.1.22';

--- a/uninstall.js
+++ b/uninstall.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { homedir, platform } from 'os';
+import { join } from 'path';
+import { readFileSync, writeFileSync, existsSync, appendFileSync, copyFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Determine OS and set appropriate config path and command
+const isWindows = platform() === 'win32';
+const claudeConfigPath = isWindows
+    ? join(process.env.APPDATA, 'Claude', 'claude_desktop_config.json')
+    : join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+
+// Create backup filename with timestamp
+const getBackupFilename = (originalPath) => {
+    const now = new Date();
+    const timestamp = `${now.getFullYear()}.${(now.getMonth() + 1).toString().padStart(2, '0')}.${now.getDate().toString().padStart(2, '0')}-${now.getHours().toString().padStart(2, '0')}.${now.getMinutes().toString().padStart(2, '0')}`;
+    const pathObj = originalPath.split('.');
+    const extension = pathObj.pop();
+    return `${pathObj.join('.')}-bk-${timestamp}.${extension}`;
+};
+
+// Setup logging
+const LOG_FILE = join(__dirname, 'uninstall.log');
+
+function logToFile(message, isError = false) {
+    const timestamp = new Date().toISOString();
+    const logMessage = `${timestamp} - ${isError ? 'ERROR: ' : ''}${message}\n`;
+    try {
+        appendFileSync(LOG_FILE, logMessage);
+        // For setup script, we'll still output to console
+        console.log(isError ? `ERROR: ${message}` : message);
+    } catch (err) {
+        // Last resort error handling
+        console.error(`Failed to write to log file: ${err.message}`);
+    }
+}
+
+// Main uninstall function
+async function uninstall() {
+    logToFile('Starting uninstall for ClaudeComputerCommander...');
+
+    // Check if config file exists
+    if (!existsSync(claudeConfigPath)) {
+        logToFile(`Claude config file not found at: ${claudeConfigPath}`, true);
+        logToFile('Please make sure Claude Desktop is installed and has been run at least once.');
+        process.exit(1);
+    }
+
+    // Create backup of config file
+    const backupPath = getBackupFilename(claudeConfigPath);
+    try {
+        copyFileSync(claudeConfigPath, backupPath);
+        logToFile(`Created backup of Claude config at: ${backupPath}`);
+    } catch (err) {
+        logToFile(`Error creating backup: ${err.message}`, true);
+        logToFile('Please make sure you have permissions to write to the Claude config directory.');
+        process.exit(1);
+    }
+
+    // Read config content
+    let configContent;
+    try {
+        configContent = readFileSync(claudeConfigPath, 'utf8');
+        logToFile('Successfully read Claude configuration');
+    } catch (err) {
+        logToFile(`Error reading Claude configuration: ${err.message}`, true);
+        process.exit(1);
+    }
+
+    // Parse config as JSON
+    let config;
+    try {
+        config = JSON.parse(configContent);
+        logToFile('Successfully parsed Claude configuration');
+    } catch (err) {
+        logToFile(`Error parsing Claude configuration: ${err.message}`, true);
+        logToFile('The configuration file appears to be invalid JSON.');
+        process.exit(1);
+    }
+
+    // Check if desktopCommander is present
+    if (!config.mcpServers || !config.mcpServers.desktopCommander) {
+        logToFile('Desktop Commander is not found in Claude configuration.');
+        logToFile('Nothing to uninstall. Exiting...');
+        process.exit(0);
+    }
+
+    // Remove desktopCommander server
+    delete config.mcpServers.desktopCommander;
+    logToFile('Removed desktopCommander from mcpServers configuration');
+
+    // If mcpServers section is now empty, clean it up
+    if (Object.keys(config.mcpServers).length === 0) {
+        delete config.mcpServers;
+        logToFile('Removed empty mcpServers section from configuration');
+    }
+
+    try {
+        // Write the updated config back
+        writeFileSync(claudeConfigPath, JSON.stringify(config, null, 2), 'utf8');
+        logToFile(`Successfully updated Claude configuration at: ${claudeConfigPath}`);
+    } catch (err) {
+        logToFile(`Error writing Claude configuration: ${err.message}`, true);
+        logToFile('Please ensure you have write permissions to the Claude config directory.');
+        logToFile('You can manually remove the desktopCommander entry from the mcpServers section in:');
+        logToFile(`${claudeConfigPath}`);
+        process.exit(1);
+    }
+
+    // Final message
+    logToFile('\nUninstallation completed successfully!');
+    logToFile('Please restart Claude Desktop to apply the changes.');
+    logToFile('\nNote: This only removes the server configuration from Claude.');
+    logToFile('To completely remove the package, run:');
+    logToFile('npm uninstall -g @jasondsmith72/desktop-commander');
+}
+
+// Run the uninstall
+uninstall().catch(err => {
+    logToFile(`Unhandled error during uninstall: ${err.message}`, true);
+    process.exit(1);
+});


### PR DESCRIPTION
This PR adds an uninstall script to make it easy for users to cleanly remove the ClaudeComputerCommander from their Claude Desktop configuration.

## New Features

- **Uninstall Script**: A dedicated script to safely remove the MCP server from Claude Desktop
- **Documentation Updates**: New section in the README explaining uninstallation options
- **Version Bump**: Updated to version 0.1.22

## What the Uninstall Script Does

1. Creates a backup of the existing Claude config file
2. Removes the `desktopCommander` entry from the `mcpServers` section
3. Cleans up the `mcpServers` section if it becomes empty
4. Logs the entire process for transparency and debugging

## How to Use

After merging, users can uninstall using:

```bash
# If installed locally:
npm run uninstall

# If installed globally:
npx @jasondsmith72/desktop-commander uninstall
```

The script provides clear instructions and creates backups automatically for safe uninstallation.
